### PR TITLE
Update sol4k to 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.sol4k:sol4k:0.7.0'
+    implementation 'org.sol4k:sol4k:0.8.0'
 }
 


### PR DESCRIPTION
Bumps `org.sol4k:sol4k` from 0.7.0 to 0.8.0 (latest release on Maven Central). Verified with `./gradlew build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)